### PR TITLE
Downgrade PyYAML because 4.1 release is missing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ msgpack==0.5.1 # pyup: ignore
 xxhash==1.0.1
 lmdb==0.94
 regex==2018.06.21
-PyYAML==4.1
+PyYAML==3.12
 # Delayed import
 psycopg2==2.7.5
 # Code style checks


### PR DESCRIPTION
PyYAML broke itself, see https://github.com/yaml/pyyaml/issues/193

Downgrading to most previously used version. PyUp will notify us when 4.2 is released.